### PR TITLE
Updated outdated path.py dependency name

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -6,7 +6,7 @@ channels:
   - defaults
 dependencies:
   - clangdev=9.0.1
-  - cadquery::occt=7.4.0
+  - occt=7.4.0
   - pybind11=2.4.3
   - python=3.6
   - joblib
@@ -18,7 +18,7 @@ dependencies:
     - clang==6.0.0
     - click
     - cymbal
-    - jinja2
+    - jinja2==2.11.3
     - logzero
     - pandas
     - path.py

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     install_requires=[
         'click',
         'logzero',
-        'path.py',
+        'path',
         'clang',
         'cymbal',
         'toml',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'pandas',
         'joblib',
         'tqdm',
-        'jinja2',
+        'jinja2==2.11.3',
         'toposort',
         'pyparsing',
         'pybind11',


### PR DESCRIPTION
OS: Ubuntu 20.04 64-bit, Python 3.8.6

The `path.py` dependency in setup.py is the old package name which has since been renamed to just `path`. This was causing an older version of the path module to be installed, which was causing Python to throw an error because it expected a `0o` prefix in `mkdir()` instead of just a leading `0`.

[Old Path Package](https://pypi.org/project/path.py/)
[New Path Package](https://pypi.org/project/path/)

Here's the full stack trace (Ubuntu 20.04) that led to this PR.

```
$ python3 -m bindgen -n 1 -v parse ocp.toml out.pkl && python -m bindgen -n 1 -v transform ocp.toml out.pkl out_f.pkl && python -m bindgen -n 1 -v generate ocp.toml out_f.pkl
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 185, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.8/runpy.py", line 144, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/usr/lib/python3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/home/jwright/Downloads/pywrap/bindgen/__init__.py", line 11, in <module>
    from path import Path
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 914, in _find_spec
  File "<frozen importlib._bootstrap_external>", line 1342, in find_spec
  File "<frozen importlib._bootstrap_external>", line 1316, in _get_spec
  File "<frozen importlib._bootstrap_external>", line 1297, in _legacy_get_spec
  File "<frozen importlib._bootstrap>", line 414, in spec_from_loader
  File "<frozen importlib._bootstrap_external>", line 649, in spec_from_file_location
  File "<frozen zipimport>", line 191, in get_filename
  File "<frozen zipimport>", line 713, in _get_module_code
  File "<frozen zipimport>", line 647, in _compile_source
  File "/home/jwright/venvs/ocp/lib/python3.8/site-packages/path-2.2-py3.8.egg/path.py", line 886
    def mkdir(self, mode=0777):
                            ^
SyntaxError: leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers
```