### PR TITLE
Add support for byref methods that return Standard_Boolean instead of void (#45)

### DIFF
--- a/bindgen/__init__.py
+++ b/bindgen/__init__.py
@@ -99,7 +99,7 @@ def is_byref(met,byref_types):
 
     rv = False
 
-    if met.return_type == 'void':
+    if met.return_type == 'void' or met.return_type == 'Standard_Boolean':
         for _,arg,_ in met.args:
             if any(arg.startswith(byref_t) and arg.endswith('&')
                    for byref_t in byref_types):
@@ -159,7 +159,6 @@ def transform_module(m,
 
     if byref_types:
         for c in m.classes:
-
             c.methods_byref = [met for met in c.methods if is_byref(met,byref_types)]
             c.methods_return_byref = [met for met in c.methods if is_byref_return(met) and not met.pure_virtual]
             c.static_methods_byref = [met for met in c.static_methods if is_byref(met,byref_types)]
@@ -379,6 +378,7 @@ def render(settings,module_settings,modules,class_dict):
         'parent_has_nonpublic_destructor' : lambda c: any(all_classes[p].nonpublic_destructors for p in c.superclasses if p in all_classes),
         'is_byref' : lambda t: is_byref_arg(t,settings['byref_types']),
         'is_byref_smart_ptr' : lambda t: is_byref_arg(t,settings['byref_types_smart_ptr']),
+        'is_boolean_return': lambda t: t.return_type == 'Standard_Boolean',
         'args_byref' : lambda f: [arg for arg,t,_ in f.args if is_byref_arg(t,settings['byref_types'])],
         'enumerate' : enumerate,
         'platform' : platform,

--- a/bindgen/template_sub.j2
+++ b/bindgen/template_sub.j2
@@ -117,9 +117,9 @@ py::object klass;
         .def("{{m.name}}",
              []( {{c.name}} &self {{ "," if argtypes_names_not_byref(m)|length}} {{argtypes_names_not_byref(m)}} ){ 
                  {{init_outputs_byref(m) | indent(16) }}
-                 self.{{m.name}}({{argnames_wo_type(m)}});
+                 {%+ if is_boolean_return(m) +%}Standard_Boolean rv = {% endif %}self.{{m.name}}({{argnames_wo_type(m)}});
                  {{handle_results_ptr_byref(m) | indent(16) }}
-                 return std::make_tuple({{argnames_byref(m)}}); },
+                 return std::make_tuple({% if is_boolean_return(m) %}rv,{% endif %}{{argnames_byref(m)}}); },
              R"#({{m.comment}})#" {{argnames_not_byref(m)}}
           )
     {% endif %}
@@ -139,9 +139,9 @@ py::object klass;
         .def_static("{{m.name}}_s",
             []({{argtypes_names_not_byref(m)}} ){ 
                 {{init_outputs_byref(m) | indent(16) }}
-                {{c.name}}::{{m.name}}({{argnames_wo_type(m)}});
+                {%+ if is_boolean_return(m) +%}Standard_Boolean rv = {% endif %}{{c.name}}::{{m.name}}({{argnames_wo_type(m)}});
                 {{handle_results_ptr_byref(m) | indent(16) }}
-                {% if args_byref(m) %}return std::make_tuple({{argnames_byref(m)}});{% endif %} },
+                {% if args_byref(m) %}return std::make_tuple({% if is_boolean_return(m) %}rv,{% endif %}{{argnames_byref(m)}});{% endif %} },
             R"#({{m.comment}})#" {{argnames_not_byref(m)}}
           )
     {% endif %}


### PR DESCRIPTION
(This is a proof of concept PR)

Well, we're in a pickle. This rather backwards incompatible change appears to affect 101 rendered cpp files and 632 methods where the return value has been previously ignored. 

Adaptor3d.cpp
BRepGProp.cpp
IGESDraw.cpp
BRepBlend.cpp
IntPatch.cpp
TPrsStd.cpp
ProjLib.cpp
StepToTopoDS.cpp
XmlMDF.cpp
ShapeCustom.cpp
RWStepAP214.cpp
math.cpp
ShapeFix.cpp
TDF.cpp
TopOpeBRepBuild.cpp
IGESGeom.cpp
BRepFilletAPI.cpp
IGESGraph.cpp
Graphic3d.cpp
STEPConstruct.cpp
Contap.cpp
BRepLib.cpp
IFSelect.cpp
TNaming.cpp
OpenGl.cpp
BOPTools.cpp
IGESData.cpp
FairCurve.cpp
CDM.cpp
IGESSelect.cpp
CSLib.cpp
IntTools.cpp
TopOpeBRep.cpp
ShapeUpgrade.cpp
Bnd.cpp
IGESSolid.cpp
GeomInt.cpp
IGESToBRep.cpp
TDataStd.cpp
SelectMgr.cpp
ChFi3d.cpp
ShapeExtend.cpp
TopOpeBRepTool.cpp
BRepClass.cpp
Extrema.cpp
Aspect.cpp
XCAFDimTolObjects.cpp
StepAP209.cpp
Interface.cpp
BRepTools.cpp
Bisector.cpp
ShapeAnalysis.cpp
BRepFeat.cpp
AdvApprox.cpp
BRepOffset.cpp
Transfer.cpp
AppDef.cpp
Prs3d.cpp
MeshVS.cpp
gp.cpp
Draft.cpp
BRepApprox.cpp
TDataXtd.cpp
ShapeProcess.cpp
HLRBRep.cpp
GeomAPI.cpp
XSControl.cpp
IGESDefs.cpp
IntCurve.cpp
XCAFDoc.cpp
TObj.cpp
BRepMesh.cpp
CPnts.cpp
IGESDimen.cpp
LocOpe.cpp
GeomLib.cpp
TFunction.cpp
IGESBasic.cpp
XmlObjMgt.cpp
AdvApp2Var.cpp
BOPDS.cpp
Geom2dInt.cpp
IGESAppli.cpp
TopOpeBRepDS.cpp
BRepClass3d.cpp
STEPCAFControl.cpp
AIS.cpp
XCAFPrs.cpp
ShapeAlgo.cpp
Geom.cpp
ShapeConstruct.cpp
IntCurveSurface.cpp
BRepExtrema.cpp
Geom2dLProp.cpp
TopoDSToStep.cpp
Geom2dHatch.cpp
StepData.cpp
Geom2dGcc.cpp
GCPnts.cpp
BSplCLib.cpp
GeomFill.cpp