### PR TITLE
Update __init__.py

### DIFF
--- a/bindgen/__init__.py
+++ b/bindgen/__init__.py
@@ -46,7 +46,7 @@ def read_symbols(p):
     '''
 
     sym = pd.read_csv(p,header=None,names=['name'],delim_whitespace=True,
-                      error_bad_lines=False).dropna()
+                      on_bad_lines=False).dropna()
     return sym
 
 def remove_undefined_mangled(m,sym):


### PR DESCRIPTION
`error_bad_lines` as been deprecated in pandas 2.0 and since there is no upper version limit it result in a broken install. This should fix the issue