### PR TITLE
run clang without default config

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,3 @@ jobs:
   parameters:
     name: Windows
     vmImage: 'windows-2019'
-- template: build-bindings-job.yml
-  parameters:
-    name: OSX
-    vmImage: 'macOS-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,4 +25,4 @@ jobs:
 - template: build-bindings-job.yml
   parameters:
     name: OSX
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-latest'

--- a/bindgen/translation_unit.py
+++ b/bindgen/translation_unit.py
@@ -31,6 +31,11 @@ def parse_tu(path,
     for inc in platform_includes:
         args.append(f'-I{inc}')
 
+    # if clang is configured with a system-wide config file, then some additional
+    # unexpected headers might be added by the indexer during parsing and those ones will 
+    # have a None filename location
+    args.append('--no-default-config')
+
     ix = get_index()
 
     with open(path) as f:


### PR DESCRIPTION
clang can be installed with a system-wide config-file which might add unexpected includes files in the chain. Those files will result in an undefined location when querying the index, let's avoid that problem by configuring clang to be executed without a default config file