### PR TITLE
add support to include files with BOM character

### DIFF
--- a/bindgen/translation_unit.py
+++ b/bindgen/translation_unit.py
@@ -41,6 +41,10 @@ def parse_tu(path,
     with open(path) as f:
         src = f.read()
 
+    # skip possible invisible BOM character which would lead to clang error later
+    if src[0] == "\ufeff" :
+        src = src[1:]
+
     dummy_code = f'{parsing_header}\n{platform_parsing_header}\n{tu_parsing_header}\n{src}'
     tr_unit = ix.parse('dummy.cxx',
                        args,


### PR DESCRIPTION
some upstream opencascade files include a BOM character at the beginning which leads to an error when parsing the file by clang

This will make out-of-date two other OCP PRs https://github.com/CadQuery/OCP/pull/134 and https://github.com/CadQuery/OCP/pull/135. The proposed solution here doesn't require to patch the opencascade include files which might come also from the user system.