### PR TITLE
fix support of clang-15

### DIFF
--- a/bindgen/translation_unit.py
+++ b/bindgen/translation_unit.py
@@ -3,7 +3,7 @@ import pybind11
 
 from clang.cindex import TranslationUnit as TU
 
-from .utils import get_index, get_includes
+from .utils import get_index, get_includes, get_clang_version
 
 
 
@@ -34,7 +34,8 @@ def parse_tu(path,
     # if clang is configured with a system-wide config file, then some additional
     # unexpected headers might be added by the indexer during parsing and those ones will 
     # have a None filename location
-    args.append('--no-default-config')
+    if get_clang_version() > 15 :
+        args.append('--no-default-config')
 
     ix = get_index()
 

--- a/bindgen/utils.py
+++ b/bindgen/utils.py
@@ -56,6 +56,7 @@ def get_clang_version() :
 
     if not initialized: init_clang()
 
+    # clangVersion should be a string like "clang version MAJOR.MINOR.PATCH"
     return int(clangVersion.split()[-1].split(".")[0])
 
 


### PR DESCRIPTION
The previous patch I submitted is creating problems with clang-15 as the option --no-default-config is available from  clang-16 only. Now is also possible to detect clang version which can be useful in the future.