### PR TITLE
fix: remove deprecated delim_whitespace

### DIFF
--- a/bindgen/__init__.py
+++ b/bindgen/__init__.py
@@ -46,7 +46,7 @@ def read_symbols(p):
     '''
 
     if int(pd.__version__.split('.')[0]) >= 2:
-        sym = pd.read_csv(p,header=None,names=['name'],delim_whitespace=True,
+        sym = pd.read_csv(p,header=None,names=['name'],sep="\\s+",
                           on_bad_lines='skip').dropna()
     else:
         sym = pd.read_csv(p,header=None,names=['name'],delim_whitespace=True,


### PR DESCRIPTION
Pandas deprecated the `delim_whitespace` argument for `read_csv` in version [2.2.0](https://pandas.pydata.org/docs/whatsnew/v2.2.0.html) opting instead for `sep="\\s+"`.