### PR TITLE
prefer newer "tomli" over "toml"

### DIFF
--- a/bindgen/__init__.py
+++ b/bindgen/__init__.py
@@ -5,7 +5,7 @@ from sys import platform
 from typing import List
 
 import logzero
-import toml as toml
+import tomli
 import pandas as pd
 import pyparsing as pp
 
@@ -23,8 +23,8 @@ from .schemas import global_schema, module_schema
 
 def read_settings(p):
 
-    with open(p) as f:
-        settings = toml.load(f)
+    with open(p, 'rb') as f:
+        settings = tomli.load(f)
 
     # validate
     settings = global_schema.validate(settings)

--- a/env.yml
+++ b/env.yml
@@ -10,7 +10,7 @@ dependencies:
   - pybind11=2.4.3
   - python=3.6
   - joblib
-  - toml
+  - tomli
   - pip
   - cmake=3.16
   - ninja

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "logzero",
         "path",
         "clang",
-        "toml",
+        "tomli",
         "pandas",
         "joblib",
         "tqdm",


### PR DESCRIPTION
Hi,

We are slowly trying to remove old `toml` from Debian.

https://wiki.debian.org/Python/Backports