### PR TITLE
Fix arg.name → arg.arg_name in macros.j2 byref smart pointer wrapping

### DIFF
--- a/bindgen/macros.j2
+++ b/bindgen/macros.j2
@@ -41,7 +41,7 @@
     {% for arg in f.args if is_byref(arg.arg_type) %}{{ arg.arg_type[:-1] }} {{ arg.arg_name }};
     {% endfor %}
     {% for arg in f.args if is_byref_smart_ptr(arg.arg_type) -%}
-    {{ arg.arg_type[:-1] }} {{ arg.name }}_ptr; {{ arg.name }}_ptr = &{{arg.name}};
+    {{ arg.arg_type[:-1] }} {{ arg.arg_name }}_ptr; {{ arg.arg_name }}_ptr = &{{arg.arg_name}};
     {% endfor %}
 {%- endmacro -%}
 


### PR DESCRIPTION
## Summary
- `init_outputs_byref` macro (macros.j2:44) uses `arg.name` which doesn't
  exist on `ArgInfo` — the correct field is `arg.arg_name` (since 4338109)
- Jinja2 silently renders the missing attribute as empty string, producing
  broken C++ (`_ptr; _ptr = &;`) instead of a template error
- Affects all platforms — 377 broken declarations across 65 generated files