### PR TITLE
Use -idirafter for system includes

### DIFF
--- a/bindgen/translation_unit.py
+++ b/bindgen/translation_unit.py
@@ -38,7 +38,7 @@ def parse_tu(
         args.append(f"--sysroot={prefix}")
 
     for inc in get_includes():
-        args.append(f"-I{inc}")
+        args.extend(["-idirafter", inc])
 
     for inc in platform_includes:
         args.append(f"-I{inc}")


### PR DESCRIPTION
## Summary
- Changes `get_includes()` paths from `-I` to `-idirafter` in `translation_unit.py`
- Prevents include-path conflicts when libclang version differs from the system compiler (e.g. FreeBSD with clang-19 system headers and libclang-21), where `-I` breaks `#include_next` chains
- Safe no-op on platforms where versions already match

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>